### PR TITLE
fix contributor list on package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "contributors": [
     "Michael Salvati <info@msalvati.com> (https://github.com/3daddict)",
     "Mateo Guzmán <mateo.guzmanalvarez@gmail.com> (https://github.com/mateoguzmana/)",
-    "Robin Hurtado <robin_aven94@hotmail.com> (https://github.com/robinHurtado/)"
+    "Robin Hurtado <robin_aven94@hotmail.com> (https://github.com/robinHurtado/)",
     "David Aguilar <davidaguilarh.94@gmail.com> (https://github.com/daguilar94)"
   ],
   "license": "ISC",


### PR DESCRIPTION
A faulty typo on the contributor list in package.json breaks npm-install